### PR TITLE
Fix the 7z dependancy download

### DIFF
--- a/.github/workflows/on_push_main.yml
+++ b/.github/workflows/on_push_main.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'debug**'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/reusable_workflow.yml
+++ b/.github/workflows/reusable_workflow.yml
@@ -47,14 +47,13 @@ jobs:
       - name: Install nsis, wget and unzip
         run: sudo apt install -y nsis wget unzip p7zip-full git
 
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Download 7-zip
         run: |
           wget https://www.7-zip.org/a/7z2201-extra.7z
           7z x 7z2201-extra.7z
-          ls 7za.exe
-
-      - name: Checkout
-        uses: actions/checkout@v4
 
       - name: Remove .env file
         run: rm .env

--- a/.github/workflows/reusable_workflow.yml
+++ b/.github/workflows/reusable_workflow.yml
@@ -51,6 +51,7 @@ jobs:
         run: |
           wget https://www.7-zip.org/a/7z2201-extra.7z
           7z x 7z2201-extra.7z
+          ls 7za.exe
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This was an issue with the order in the pipeline.
Any downloads in the working dir should happen AFTER the github workflow "checkout" step