### PR TITLE
fix: Re-enable installer exe compression

### DIFF
--- a/templates/rs-liveries.nsi.j2
+++ b/templates/rs-liveries.nsi.j2
@@ -21,10 +21,10 @@ Icon "rs.ico"
 
 ; Let's compress as much as possible. /SOLID breaks the installer in case of too many big files (2gb +)!
 ; SetCompressor /FINAL zlib
-; SetCompressor /SOLID /FINAL lzma ; This gave us a trojan false positive... trying without
+SetCompressor /SOLID /FINAL lzma ; Toggle this if you get a trojan false positive.
 
 ; LZMA compression only
-; SetCompressorDictSize 128
+SetCompressorDictSize 128
 
 
 ; The name of the installer


### PR DESCRIPTION
We are doing this because current release is
being flagged as a false positive (trojan).

Aside from Windows Defender, VirusTotal says
"DeepInsight" also considers it a trojan.

Disabling compression got us around the problem
the last time. Hopefully re-enabling works again.