### PR TITLE
Make the previously hidden fixes section visible

### DIFF
--- a/templates/rs-liveries.nsi.j2
+++ b/templates/rs-liveries.nsi.j2
@@ -215,7 +215,7 @@ ${EndIf}
 !macroend
 
 ; This is a secret section that's not visible to the user
-Section "-Clean up our mistakes"
+Section "Apply fixes to known problems"
   ;
   ; Clean up our mistakes
   ;


### PR DESCRIPTION
We are getting false positives and I'm just trying to see what is triggering WindowsDefender and Deepinsight to classify the exe as a Trojan. Hopefully this fixes it.