### PR TITLE
feature: Virustotal scanning on release

### DIFF
--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -32,3 +32,19 @@ jobs:
     secrets:
       GOOGLE_CREDS: ${{ secrets.GOOGLE_CREDS }}
       ASSETS: ${{ secrets.ASSETS }}
+  virustotal:
+    needs: main_release
+    runs-on: ${{ startsWith( github.ref_name, 'test' ) && 'self-hosted' || 'ubuntu-22.04' }}
+    steps:
+      - name: Sleep for 60 seconds
+        run: sleep 60s
+        shell: bash
+      
+      - name: VirusTotal Scan
+        uses: crazy-max/ghaction-virustotal@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          update_release_body: true
+          vt_api_key: ${{ secrets.VT_API_KEY }}
+          files: |
+            .exe$

--- a/doc/dev/Readme.md
+++ b/doc/dev/Readme.md
@@ -336,3 +336,11 @@ Once a release is created on the main branch, a workflow will trigger. It curren
 ### Et voila
 
 Once the release is done, do another test, and then distribute to folks waiting for their fancy planes!
+
+
+## VirusTotal automated scanning
+
+This required setting up a free VirusTotal account and then using the [virustotal][virustotal-gh-action] github action in the workflow.
+We are scanning all released `.exe` files at the time of writing this.
+
+[virustotal-gh-action]: https://github.com/marketplace/actions/virustotal-github-action


### PR DESCRIPTION
We are now using virustotal to scan our .exe file(s)
That are released. Currently not applied to test releases.