### PR TITLE
Update dependabot configuration for ecosystem and schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,9 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
+  - package-ecosystem: "uv" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     assignees:
       - "Kaurin"


### PR DESCRIPTION
Changed dependency update schedule from weekly to monthly and updated package ecosystem from 'pip' to 'uv'.